### PR TITLE
Fix glClear() not clearing whole buffer area due to previous scissor …

### DIFF
--- a/src/nanovg.h
+++ b/src/nanovg.h
@@ -70,8 +70,10 @@ void* nvg__getUptr(void* ctx);
 #define nvgViewport(x, y, w, h) glViewport(x, y, w, h)
 #define nvgReadPixels(nvg, image, x, y, w, h, data) nvgluReadPixels(nvg, image, x, y, w, h, data)
 #define nvgBlitFramebuffer(nvg, fb, x, y, w, h) nvgluBlitFramebuffer(nvg, fb, x, y, w, h)
-#define nvgClear(nvg) glClearColor (0, 0, 0, 0); \
-                      glClear (GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT)
+#define nvgClear(nvg) glDisable(GL_SCISSOR_TEST); \
+                      glClearColor(0, 0, 0, 0); \
+                      glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT); \
+                      glEnable(GL_SCISSOR_TEST);
 #define nvgClearWithColor(nvg, col) nvglClearWithColor(col)
 #define NVGframebuffer NVGLUframebuffer
 #endif


### PR DESCRIPTION
Fix glClear() not clearing whole buffer area due to previous scissor test.
So we turn off scissor testing - clear - then enable scissor testing.

This mainly fixes pdlua needing to clear the framebuffer, (but as the scissor test was active it was only clearing the scissor area). 
Without:
![image](https://github.com/user-attachments/assets/b2088fab-720d-42b8-aa8c-7f36f1805d02)
With:
![image](https://github.com/user-attachments/assets/181861ca-9699-401a-a33f-78feb1cc1984)
